### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Documentation
 on:
   push:
     branches: [main]
+    paths:
+      - Sources/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/docs.yml
 
 permissions:
   contents: read
@@ -16,8 +21,9 @@ concurrency:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Build documentation
         run: |
           swift package --allow-writing-to-directory ./docs \
@@ -36,6 +42,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,13 +2,32 @@ name: macOS
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/macOS.yml
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,33 @@ name: ubuntu
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Sources/**
+      - Tests/**
+      - Package.swift
+      - Package.resolved
+      - .github/workflows/ubuntu.yml
+
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Standardizes GitHub Actions for this PUBLIC swift-spm repo to match the CorvidLabs/merlin CI standard.

## Changes
- **macOS.yml** (CI): scoped triggers to `main` with a swift-spm `paths:` filter (`Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, self-ref); added a `pull_request` trigger; added `concurrency` group with `cancel-in-progress`. Runner stays `macos-latest` (GitHub-hosted, correct for PUBLIC). Bumped `actions/checkout@v5`, added `timeout-minutes`.
- **ubuntu.yml** (CI): same `paths:` filter + `pull_request` trigger + `concurrency`. Runner stays `ubuntu-latest`/`swift:6.0` container (GitHub-hosted, correct for PUBLIC). Bumped checkout to v5, added timeout.
- **docs.yml** (Pages deploy): added a source-scoped `paths:` filter (`Sources/**`, `Package.swift`, `Package.resolved`, self-ref) so non-source pushes don't redeploy docs; kept existing `pages` concurrency. Runners (`macos-latest` build, `ubuntu-latest` deploy) are GitHub-hosted, correct for PUBLIC. Bumped checkout to v5, added timeouts.

## Notes
- README/docs/LICENSE-only changes now match no CI path set and trigger nothing.
- No `fledge.toml` present, so native `swift build`/`swift test` step logic is preserved as-is.
- Validated with `python3 yaml.safe_load` and `actionlint` (clean).

Mirrors the CorvidLabs/merlin CI standard.